### PR TITLE
Fixed path3 lighting on real PS2

### DIFF
--- a/src/engine/include/models/light_bulb.hpp
+++ b/src/engine/include/models/light_bulb.hpp
@@ -17,7 +17,7 @@
 struct LightBulb
 {
     Vector3 position;
-    u16 intensity;
+    u8 intensity;
 };
 
 #endif

--- a/src/engine/include/modules/light.hpp
+++ b/src/engine/include/modules/light.hpp
@@ -24,7 +24,7 @@ public:
     ~Light();
 
     static u16 getLightsCount(u32 t_bulbsCount);
-    static void calculateLight(VECTOR *t_lightDirections, VECTOR *t_lightColors, int *t_lightTypes, LightBulb *t_bulbs, u32 t_bulbsCount, Vector3 t_objPosition);
+    static void calculateLight(VECTOR *t_lightDirections, VECTOR *t_lightColors, int *t_lightTypes, LightBulb *t_bulbs, u32 t_lightsCount, Vector3 t_objPosition);
 
 private:
 };

--- a/src/engine/modules/gif_sender.cpp
+++ b/src/engine/modules/gif_sender.cpp
@@ -188,16 +188,16 @@ void GifSender::calc3DObject(Matrix t_perspective, Mesh &t_mesh, u32 vertexCount
         VECTOR *lights = new VECTOR[vertexCount];
         calculate_normals(normals, vertexCount, normals, localLight);
 
-        Light::calculateLight(lightDirections, lightColors, lightTypes, t_bulbs, t_bulbsCount, t_mesh.position);
+        Light::calculateLight(lightDirections, lightColors, lightTypes, t_bulbs, lightsCount, t_mesh.position);
 
         calculate_lights(lights, vertexCount, normals, lightDirections, lightColors, lightTypes, lightsCount);
 
         for (u32 i = 0; i < vertexCount; i++)
         {
             // Apply the light value to the colour.
-            colors[i][0] = (t_mesh.color.r * lights[i][0] / 128.0F);
-            colors[i][1] = (t_mesh.color.g * lights[i][1] / 128.0F);
-            colors[i][2] = (t_mesh.color.b * lights[i][2] / 128.0F);
+            colors[i][0] = (t_mesh.color.r * lights[i][0]);
+            colors[i][1] = (t_mesh.color.g * lights[i][1]);
+            colors[i][2] = (t_mesh.color.b * lights[i][2]);
             vector_clamp(colors[i], colors[i], 0.00F, 1.99F);
         }
 

--- a/src/engine/modules/light.cpp
+++ b/src/engine/modules/light.cpp
@@ -23,11 +23,13 @@ Light::~Light() {}
 // ----
 
 const u8 ADDITIONAL_LIGHTS = 1; // Ambient
+const float LIGHT_MAX = 255.0F;
+const float LIGHT_DIS_MOD = 4.0F;
 
 u16 Light::getLightsCount(u32 t_bulbsCount) { return t_bulbsCount + ADDITIONAL_LIGHTS; }
 
 /** Calculates lighting. Used in gifSender in object 3D calculations */
-void Light::calculateLight(VECTOR *t_lightDirections, VECTOR *t_lightColors, int *t_lightTypes, LightBulb *t_bulbs, u32 t_bulbsCount, Vector3 t_objPosition)
+void Light::calculateLight(VECTOR *t_lightDirections, VECTOR *t_lightColors, int *t_lightTypes, LightBulb *t_bulbs, u32 t_lightsCount, Vector3 t_objPosition)
 {
     // --- Ambient light
 
@@ -45,27 +47,30 @@ void Light::calculateLight(VECTOR *t_lightDirections, VECTOR *t_lightColors, int
 
     // ---
 
-    for (u8 i = 0; i < t_bulbsCount; i++)
+    for (u8 i = 1; i < t_lightsCount; i++)
     {
-        t_lightTypes[i + 1] = LIGHT_DIRECTIONAL;
+        t_lightTypes[i] = LIGHT_DIRECTIONAL;
 
-        Vector3 newLight = Vector3(t_objPosition.x - t_bulbs[i].position.x,
-                                   t_objPosition.y - t_bulbs[i].position.y,
-                                   t_objPosition.z - t_bulbs[i].position.z);
-
+        Vector3 newLight = Vector3(t_objPosition.x - t_bulbs[i - 1].position.x,
+                                   t_objPosition.y - t_bulbs[i - 1].position.y,
+                                   t_objPosition.z - t_bulbs[i - 1].position.z);
         newLight.normalize();
-        newLight = newLight *
-                   (.1F +
-                    (t_bulbs[i].intensity / t_bulbs[i].position.distanceTo(t_objPosition)));
+        t_lightDirections[i][0] = newLight.x;
+        t_lightDirections[i][1] = newLight.y;
+        t_lightDirections[i][2] = newLight.z;
+        t_lightDirections[i][3] = 1.0F;
 
-        t_lightDirections[i + 1][0] = newLight.x;
-        t_lightDirections[i + 1][1] = newLight.y;
-        t_lightDirections[i + 1][2] = newLight.z;
-        t_lightDirections[i + 1][3] = 1.0F;
-
-        t_lightColors[i + 1][0] = 0.8F;
-        t_lightColors[i + 1][1] = 0.8F;
-        t_lightColors[i + 1][2] = 0.8F;
-        t_lightColors[i + 1][3] = 1.0F;
+        // Intensity range 0.0F - 1.0F
+        float intensity = t_bulbs[i - 1].intensity / LIGHT_MAX;
+        // Distance range 0.0F - LIGHT_MAX * LIGHT_DIS_MOD (1020.0F at this time)
+        float distance = t_bulbs[i - 1].position.distanceTo(t_objPosition);
+        // printf("Distance:%f\n", distance);
+        distance = distance > (LIGHT_MAX - LIGHT_DIS_MOD) * LIGHT_DIS_MOD ? LIGHT_MAX - LIGHT_DIS_MOD : distance;
+        intensity /= 1.0F + (distance / LIGHT_DIS_MOD); // intensity /= 1.0F - 251.0F
+        intensity /= 3.0F;                              // it looks better
+        t_lightColors[i][0] = intensity;
+        t_lightColors[i][1] = intensity;
+        t_lightColors[i][2] = intensity;
+        t_lightColors[i][3] = 1.0F;
     }
 }


### PR DESCRIPTION
Closing https://github.com/h4570/tyra/issues/7

Problem was in filling `t_lightDirections[i]` vector (**light.cpp**).
Maximum value there is 1.0F, emulator was secretly fixing this.
