### PR TITLE
Fixed sqrt() VU0 calcs on real PS2

### DIFF
--- a/src/engine/include/models/math/vector3.hpp
+++ b/src/engine/include/models/math/vector3.hpp
@@ -39,7 +39,8 @@ public:
     Vector3 operator+(Vector3 v);
     Vector3 operator-(const Vector3 &v);
     Vector3 operator*(Vector3 &v);
-    Vector3 operator*(float t);
+    Vector3 operator*(const float &t);
+    void operator*=(const float &t);
     Vector3 operator/(float t);
     Vector3 operator-(void);
 


### PR DESCRIPTION
Lack of `vwaitq` operand, after `vsqrt`/`vrsqrt` instructions, will cause wrong calculations on real PS2