### PR TITLE
bmp_loader: Auto skipping of color table information.

### DIFF
--- a/src/engine/loaders/bmp_loader.cpp
+++ b/src/engine/loaders/bmp_loader.cpp
@@ -32,6 +32,7 @@ BmpLoader::~BmpLoader() {}
  */
 void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *t_extension)
 {
+    PRINT_LOG("Loading BMP file...");
     char *path_part1 = String::createConcatenated(t_subfolder, t_name);
     char *path_part2 = String::createConcatenated("host:", path_part1);
     char *path = String::createConcatenated(path_part2, t_extension);
@@ -50,8 +51,15 @@ void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *
 
     u32 width = (u32)header[18];
     u32 height = (u32)header[22];
+    u32 bits = (u32)header[28];
+
+    if (bits != 24)
+    {
+        PRINT_ERR("Invalid bits per pixel in .bmp file - expected 24!");
+    }
+
     o_texture.setSize(width, height, TEX_TYPE_RGB);
-    printf("BMPLoader - width: %d | height: %d\n", width, height);
+    printf("BMPLoader - width: %d | height: %d | bits: %d\n", width, height, bits);
 
     u64 rowPadded = (width * 3 + 3) & (~3);
 

--- a/src/engine/loaders/bmp_loader.cpp
+++ b/src/engine/loaders/bmp_loader.cpp
@@ -51,6 +51,7 @@ void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *
     u32 width = (u32)header[18];
     u32 height = (u32)header[22];
     u32 bits = (u32)header[28];
+    u32 dataOffset = (u32)header[10];
 
     if (bits != 24)
     {
@@ -63,6 +64,9 @@ void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *
     u64 rowPadded = (width * 3 + 3) & (~3);
 
     unsigned char row[rowPadded];
+
+    //Offset file stream to raster data
+    //fseek(file, dataOffset, SEEK_SET);
 
     u32 x = 0;
     for (u32 i = 0; i < height; i++)

--- a/src/engine/loaders/bmp_loader.cpp
+++ b/src/engine/loaders/bmp_loader.cpp
@@ -66,7 +66,7 @@ void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *
     unsigned char row[rowPadded];
 
     //Offset file stream to raster data
-    //fseek(file, dataOffset, SEEK_SET);
+    fseek(file, dataOffset, SEEK_SET);
 
     u32 x = 0;
     for (u32 i = 0; i < height; i++)

--- a/src/engine/loaders/bmp_loader.cpp
+++ b/src/engine/loaders/bmp_loader.cpp
@@ -32,7 +32,6 @@ BmpLoader::~BmpLoader() {}
  */
 void BmpLoader::load(Texture &o_texture, char *t_subfolder, char *t_name, char *t_extension)
 {
-    PRINT_LOG("Loading BMP file...");
     char *path_part1 = String::createConcatenated(t_subfolder, t_name);
     char *path_part2 = String::createConcatenated("host:", path_part1);
     char *path = String::createConcatenated(path_part2, t_extension);


### PR DESCRIPTION
Related to #21 
Code in this PR includes code changes from previous PR I requested, which introduces checking for 24bits per pixel in the bmp file. I suggest accepting that PR first, then this, for sake of chronology.