### PR TITLE
Remove some standard c++ unsed libs

### DIFF
--- a/src/engine/include/loaders/mdl_loader.hpp
+++ b/src/engine/include/loaders/mdl_loader.hpp
@@ -15,8 +15,6 @@
 #include "md2_structure.hpp"
 #include "md3_structure.hpp"
 #include <stdio.h>
-#include <iostream>
-#include <vector>
 #include <tamtypes.h>
 
 


### PR DESCRIPTION
This fixes a issue that tyra can't compile locally because @Wellinator told me that he couldn't compile tyra on his system so he decided to remove iostream and some libs to work properly.