### PR TITLE
Updated tyra install directions to include downloading assets

### DIFF
--- a/docs/install/README.MD
+++ b/docs/install/README.MD
@@ -17,9 +17,10 @@
 docker pull h4570/tyra
 git clone https://github.com/h4570/tyra.git
 ```
-3. Open `VSCode` and open previously cloned directory.
-4. In `VSCode` open `.vscode/configurations/windows-docker` and copy configuration files into `.vscode/`
-5. In `c_cpp_properties.json` fix all `YOUR-INTELLISENSE-PATH` with path from point 2.
-6. Click `CTRL+SHIFT+P`, type `Tasks: Run task` and run `Start docker container` - Repeat this step every time you want to start working with Tyra (every reboot)
-7. Click `CTRL+SHIFT+P`, type `Tasks: Run build task`
-8. Tyra should automatically compile engine, `demo` game and run `PCSX2`. If you want to compile & run tutorials, please change `buildDirectory` in `settings.json` to example `tutorials/01-hello`
+3. Download the [assets.zip](https://github.com/h4570/tyra/releases) file and unzip it into the tyra directory
+4. Open `VSCode` and open previously cloned directory.
+5. In `VSCode` open `.vscode/configurations/windows-docker` and copy configuration files into `.vscode/`
+6. In `c_cpp_properties.json` fix all `YOUR-INTELLISENSE-PATH` with path from point 2.
+7. Click `CTRL+SHIFT+P`, type `Tasks: Run task` and run `Start docker container` - Repeat this step every time you want to start working with Tyra (every reboot)
+8. Click `CTRL+SHIFT+P`, type `Tasks: Run build task`
+9. Tyra should automatically compile engine, `demo` game and run `PCSX2`. If you want to compile & run tutorials, please change `buildDirectory` in `settings.json` to example `tutorials/01-hello`


### PR DESCRIPTION
Right now the install directions don't mention you have to download the assets along with the cloned project, so the demo doesn't work. I updated the install directions to mention you have to download the assets