### PR TITLE
Fixed writeLogsToFile

### DIFF
--- a/engine/inc/debug/debug.hpp
+++ b/engine/inc/debug/debug.hpp
@@ -48,9 +48,12 @@ class TyraDebug {
     (void)expander{0, (void(ss << std::forward<Args>(args)), 0)...};
 
     if (Tyra::Info::writeLogsToFile) {
-      auto* logFile = getLogFile();
-      *logFile << ss.str();
-      logFile->flush();
+      std::ofstream logFile;
+      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
+                  std::ofstream::out | std::ofstream::app);
+      logFile << ss.str();
+      logFile.flush(); 
+      // logFile.close();
     } else {
       printf("%s", ss.str().c_str());
     }
@@ -65,9 +68,12 @@ class TyraDebug {
     ss1 << "|\n";
 
     if (Tyra::Info::writeLogsToFile) {
-      auto* logFile = getLogFile();
-      *logFile << ss1.str();
-      logFile->flush();
+      std::ofstream logFile;
+      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
+                  std::ofstream::out | std::ofstream::app);
+      logFile << ss1.str();
+      logFile.flush();
+      // logFile.close();
     } else {
       printf("%s", ss1.str().c_str());
     }
@@ -80,9 +86,12 @@ class TyraDebug {
     ss2 << "====================================\n\n";
 
     if (Tyra::Info::writeLogsToFile) {
-      auto* logFile = getLogFile();
-      *logFile << ss2.str();
-      logFile->flush();
+      std::ofstream logFile;
+      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
+                  std::ofstream::out | std::ofstream::app);
+      logFile << ss2.str();
+      logFile.flush();
+      // logFile.close();
     } else {
       printf("%s", ss2.str().c_str());
     }
@@ -92,9 +101,6 @@ class TyraDebug {
   }
 
  private:
-  static std::unique_ptr<std::ofstream> logFile;
-  static std::ofstream* getLogFile();
-
   template <typename Arg, typename... Args>
   static void writeAssertLines(Arg&& arg, Args&&... args) {
     std::stringstream ss;
@@ -105,9 +111,12 @@ class TyraDebug {
         0, (void(ss << "| " << std::forward<Args>(args) << "\n"), 0)...};
 
     if (Tyra::Info::writeLogsToFile) {
-      auto* logfile = getLogFile();
-      *logfile << ss.str();
-      logFile->flush();
+      std::ofstream logFile;
+      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
+                  std::ofstream::out | std::ofstream::app);
+      logFile << ss.str();
+      logFile.flush();
+      // logFile.close();
     } else {
       printf("%s", ss.str().c_str());
     }

--- a/engine/inc/debug/debug.hpp
+++ b/engine/inc/debug/debug.hpp
@@ -87,7 +87,7 @@ class TyraDebug {
 
  private:
   static void writeInLogFile(std::stringstream* ss);
-  
+
   template <typename Arg, typename... Args>
   static void writeAssertLines(Arg&& arg, Args&&... args) {
     std::stringstream ss;

--- a/engine/inc/debug/debug.hpp
+++ b/engine/inc/debug/debug.hpp
@@ -50,9 +50,9 @@ class TyraDebug {
     if (Tyra::Info::writeLogsToFile) {
       std::ofstream logFile;
       logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                  std::ofstream::out | std::ofstream::app);
+                   std::ofstream::out | std::ofstream::app);
       logFile << ss.str();
-      logFile.flush(); 
+      logFile.flush();
       // logFile.close();
     } else {
       printf("%s", ss.str().c_str());
@@ -70,7 +70,7 @@ class TyraDebug {
     if (Tyra::Info::writeLogsToFile) {
       std::ofstream logFile;
       logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                  std::ofstream::out | std::ofstream::app);
+                   std::ofstream::out | std::ofstream::app);
       logFile << ss1.str();
       logFile.flush();
       // logFile.close();
@@ -88,7 +88,7 @@ class TyraDebug {
     if (Tyra::Info::writeLogsToFile) {
       std::ofstream logFile;
       logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                  std::ofstream::out | std::ofstream::app);
+                   std::ofstream::out | std::ofstream::app);
       logFile << ss2.str();
       logFile.flush();
       // logFile.close();
@@ -113,7 +113,7 @@ class TyraDebug {
     if (Tyra::Info::writeLogsToFile) {
       std::ofstream logFile;
       logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                  std::ofstream::out | std::ofstream::app);
+                   std::ofstream::out | std::ofstream::app);
       logFile << ss.str();
       logFile.flush();
       // logFile.close();

--- a/engine/inc/debug/debug.hpp
+++ b/engine/inc/debug/debug.hpp
@@ -48,12 +48,7 @@ class TyraDebug {
     (void)expander{0, (void(ss << std::forward<Args>(args)), 0)...};
 
     if (Tyra::Info::writeLogsToFile) {
-      std::ofstream logFile;
-      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                   std::ofstream::out | std::ofstream::app);
-      logFile << ss.str();
-      logFile.flush();
-      // logFile.close();
+      writeInLogFile(&ss);
     } else {
       printf("%s", ss.str().c_str());
     }
@@ -68,12 +63,7 @@ class TyraDebug {
     ss1 << "|\n";
 
     if (Tyra::Info::writeLogsToFile) {
-      std::ofstream logFile;
-      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                   std::ofstream::out | std::ofstream::app);
-      logFile << ss1.str();
-      logFile.flush();
-      // logFile.close();
+      writeInLogFile(&ss1);
     } else {
       printf("%s", ss1.str().c_str());
     }
@@ -86,12 +76,7 @@ class TyraDebug {
     ss2 << "====================================\n\n";
 
     if (Tyra::Info::writeLogsToFile) {
-      std::ofstream logFile;
-      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                   std::ofstream::out | std::ofstream::app);
-      logFile << ss2.str();
-      logFile.flush();
-      // logFile.close();
+      writeInLogFile(&ss2);
     } else {
       printf("%s", ss2.str().c_str());
     }
@@ -101,6 +86,8 @@ class TyraDebug {
   }
 
  private:
+  static void writeInLogFile(std::stringstream* ss);
+  
   template <typename Arg, typename... Args>
   static void writeAssertLines(Arg&& arg, Args&&... args) {
     std::stringstream ss;
@@ -111,12 +98,7 @@ class TyraDebug {
         0, (void(ss << "| " << std::forward<Args>(args) << "\n"), 0)...};
 
     if (Tyra::Info::writeLogsToFile) {
-      std::ofstream logFile;
-      logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
-                   std::ofstream::out | std::ofstream::app);
-      logFile << ss.str();
-      logFile.flush();
-      // logFile.close();
+      writeInLogFile(&ss);
     } else {
       printf("%s", ss.str().c_str());
     }

--- a/engine/src/debug/debug.cpp
+++ b/engine/src/debug/debug.cpp
@@ -8,18 +8,13 @@
 # Wellington Carvalho <wellcoj@gmail.com>
 */
 
-// #include "debug/debug.hpp"
+#include "debug/debug.hpp"
 
-// std::unique_ptr<std::ofstream> TyraDebug::logFile;
-
-// std::ofstream* TyraDebug::getLogFile() {
-//   if (logFile) {
-//     return logFile.get();
-//   } else {
-//     logFile = std::make_unique<std::ofstream>();
-//     logFile->open(Tyra::FileUtils::fromCwd("log.txt"),
-//                   std::ofstream::out | std::ofstream::app);
-//     return logFile.get();
-//   }
-
-// }  // namespace Tyra
+void TyraDebug::writeInLogFile(std::stringstream* ss) {
+  std::ofstream logFile;
+  logFile.open(Tyra::FileUtils::fromCwd("log.txt"),
+               std::ofstream::out | std::ofstream::app);
+  logFile << ss->str();
+  logFile.flush();
+  // logFile.close();
+}

--- a/engine/src/debug/debug.cpp
+++ b/engine/src/debug/debug.cpp
@@ -8,18 +8,18 @@
 # Wellington Carvalho <wellcoj@gmail.com>
 */
 
-#include "debug/debug.hpp"
+// #include "debug/debug.hpp"
 
-std::unique_ptr<std::ofstream> TyraDebug::logFile;
+// std::unique_ptr<std::ofstream> TyraDebug::logFile;
 
-std::ofstream* TyraDebug::getLogFile() {
-  if (logFile) {
-    return logFile.get();
-  } else {
-    logFile = std::make_unique<std::ofstream>();
-    logFile->open(Tyra::FileUtils::fromCwd("log.txt"),
-                  std::ofstream::out | std::ofstream::app);
-    return logFile.get();
-  }
+// std::ofstream* TyraDebug::getLogFile() {
+//   if (logFile) {
+//     return logFile.get();
+//   } else {
+//     logFile = std::make_unique<std::ofstream>();
+//     logFile->open(Tyra::FileUtils::fromCwd("log.txt"),
+//                   std::ofstream::out | std::ofstream::app);
+//     return logFile.get();
+//   }
 
-}  // namespace Tyra
+// }  // namespace Tyra


### PR DESCRIPTION
The log file works on the emulator but it didn't work on real hardware.

I managed to fix it by changing the smart pointer for a file that opens and closes in the same function. Now it works on emulator and on real hardware.

I tried to make the file open only once and that it can be used many times, just like with the smart pointer, but I couldn't get it to work in the emulator and on a real PS2 at the same time.

Additional Information:
Tested on a PCSX2 1.6.0 emulator
edit: PS2 model 90001
Ulaunchelf 4.43x_isr (mod by israpps)
edit: USB 3.2 DataTraveler Exodia 16GB FAT32

Deleted logFile smart pointer and getLogFile function. 
logfile created inside of the statics functions.

