### PR TITLE
Better IRX error handling

### DIFF
--- a/engine/src/irx/irx_loader.cpp
+++ b/engine/src/irx/irx_loader.cpp
@@ -109,9 +109,9 @@ int IrxLoader::applyRpcPatches() {
 void IrxLoader::loadLibsd(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading libsd...");
 
-  int ret;
-  SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: libsd_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: libsd_irx");
 
   if (verbose) TYRA_LOG("IRX: Libsd loaded!");
 }
@@ -119,19 +119,18 @@ void IrxLoader::loadLibsd(const bool& verbose) {
 void IrxLoader::loadUsbModules(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading usb modules...");
 
-  int ret;
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbd_irx");
 
-  SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: usbd_irx");
+  irx_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdm_irx");
 
-  SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: bdm_irx");
+  irx_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdmfs_fatfs");
 
-  SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: bdmfs_fatfs");
-
-  SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: usbmass");
+  irx_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbmass");
 
   waitUntilUsbDeviceIsReady();
 
@@ -141,9 +140,9 @@ void IrxLoader::loadUsbModules(const bool& verbose) {
 void IrxLoader::loadAudsrv(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading audsrv...");
 
-  int ret;
-  SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: audsrv_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: audsrv_irx");
 
   if (verbose) TYRA_LOG("IRX: Audsrv loaded!");
 }
@@ -151,9 +150,9 @@ void IrxLoader::loadAudsrv(const bool& verbose) {
 void IrxLoader::loadSio2man(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading sio2man...");
 
-  int ret;
-  SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: sio2man_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: sio2man_irx");
 
   if (verbose) TYRA_LOG("IRX: Sio2man loaded!");
 }
@@ -161,9 +160,9 @@ void IrxLoader::loadSio2man(const bool& verbose) {
 void IrxLoader::loadPadman(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading padman...");
 
-  int ret;
-  SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: padman_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, nullptr, &ret);
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: padman_irx");
 
   if (verbose) TYRA_LOG("IRX: Padman loaded!");
 }

--- a/engine/src/irx/irx_loader.cpp
+++ b/engine/src/irx/irx_loader.cpp
@@ -111,7 +111,7 @@ void IrxLoader::loadLibsd(const bool& verbose) {
 
   int ret, irx_id;
   irx_id = SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: libsd_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: libsd_irx id:", idx_id, ", ret:", ret);
 
   if (verbose) TYRA_LOG("IRX: Libsd loaded!");
 }
@@ -121,16 +121,16 @@ void IrxLoader::loadUsbModules(const bool& verbose) {
 
   int ret, irx_id;
   irx_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbd_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbd_irx id:", idx_id, ", ret:", ret);
 
   irx_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdm_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdm_irx id:", idx_id, ", ret:", ret);
 
   irx_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdmfs_fatfs");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: bdmfs_fatfs id:", idx_id, ", ret:", ret);
 
   irx_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbmass");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: usbmass id:", idx_id, ", ret:", ret);
 
   waitUntilUsbDeviceIsReady();
 
@@ -142,7 +142,7 @@ void IrxLoader::loadAudsrv(const bool& verbose) {
 
   int ret, irx_id;
   irx_id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: audsrv_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: audsrv_irx id:", idx_id, ", ret:", ret);
 
   if (verbose) TYRA_LOG("IRX: Audsrv loaded!");
 }
@@ -152,7 +152,7 @@ void IrxLoader::loadSio2man(const bool& verbose) {
 
   int ret, irx_id;
   irx_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: sio2man_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: sio2man_irx id:", idx_id, ", ret:", ret);
 
   if (verbose) TYRA_LOG("IRX: Sio2man loaded!");
 }
@@ -162,7 +162,7 @@ void IrxLoader::loadPadman(const bool& verbose) {
 
   int ret, irx_id;
   irx_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, nullptr, &ret);
-  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: padman_irx");
+  TYRA_ASSERT((ret != 1) && (irx_id > 0), "Failed to load module: padman_irx id:", idx_id, ", ret:", ret);
 
   if (verbose) TYRA_LOG("IRX: Padman loaded!");
 }


### PR DESCRIPTION
IRX ID must be > `0`, else, an error ocurred while loading the module (see [kerr.h](https://github.com/ps2dev/ps2sdk/blob/6b656d1ae18dd2bb75a6caa03346cf9f933c12c6/iop/kernel/include/kerr.h#L39) on IOP Kernel)

return value can be `0`, `1` or `2` ([ref](https://github.com/ps2dev/ps2sdk/blob/6b656d1ae18dd2bb75a6caa03346cf9f933c12c6/iop/kernel/include/loadcore.h#L22-L24))

It could mean an error or not depending on the module behaviour, but for all the modules you use, returning 1 means an error.
0: module remains on RAM
1: module requested to be unloaded during startup (eg: error, or module does not require to remain resident)
2: module remains on RAM, but supports to be unloaded anytime by MODLOAD, (only if both module and MODLOAD version support it)