### PR TITLE
add continous integration

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - 'engine/**'
+      - 'demo/**'
+      - '**.cpp'
+      - '.github/workflows/compile.yml'
+  workflow_dispatch:
+    inputs:
+      make_args:
+        description: pass extra make argumments to Program compilation
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: h4570/tyra
+    steps:
+    - name: install deps
+      run: |
+        apt-get update
+        apt install -y git make wget
+        
+    - name: Workaround permission issue
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Compile tyra
+      run: |
+        make clean all ${{ github.event.inputs.make_args }} -C engine
+
+    - name: Compile tyra demo
+      run: |
+        make clean all -C demo
+
+    - name: Get short SHA
+      id: slug
+      run: | 
+        echo "SHA8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_ENV
+
+    - name: Get branch
+      if: github.ref != 'refs/heads/main'
+      id: brnch
+      run: | 
+        echo "BRANCH=$(echo -${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: tyra-${{ env.SHA8 }}${{ env.BRANCH }}
+        path: | 
+          engine/bin
+          demo/bin


### PR DESCRIPTION
To avoid making this PR disruptive. the workflow will only compile the engine and the demo. and upload the bin folder of the engine & demo as github artifacts, only available for registered users from the actions tab.

If you desire automated [public releases](https://github.com/h4570/tyra/releases) on a fixed tag, and only when updating the master branch, let me know before merging...