### PR TITLE
Fix sprite loading

### DIFF
--- a/engine/src/loaders/texture/png_loader.cpp
+++ b/engine/src/loaders/texture/png_loader.cpp
@@ -211,10 +211,6 @@ void PngLoader::handle8bppPalletized(TextureBuilderData* result,
   auto* pixel = static_cast<unsigned char*>(result->data);
   struct PngClut* clut = (struct PngClut*)result->clut;
 
-  for (int i = numPallete; i < 256; i++) {
-    memset(&clut[i], 0, sizeof(clut[i]));
-  }
-
   for (int i = 0; i < numPallete; i++) {
     clut[i].r = palette[i].red;
     clut[i].g = palette[i].green;
@@ -272,10 +268,6 @@ void PngLoader::handle4bppPalletized(TextureBuilderData* result,
 
   auto* pixel = static_cast<unsigned char*>(result->data);
   struct PngClut* clut = (struct PngClut*)result->clut;
-
-  for (int i = numPallete; i < 16; i++) {
-    memset(&clut[i], 0, sizeof(clut[i]));
-  }
 
   for (int i = 0; i < numPallete; i++) {
     clut[i].r = palette[i].red;

--- a/engine/src/renderer/core/paths/path3/path3.cpp
+++ b/engine/src/renderer/core/paths/path3/path3.cpp
@@ -65,20 +65,20 @@ void Path3::sendTexture(const Texture* texture,
                         const RendererCoreTextureBuffers& texBuffers) {
   packet2_reset(texturePacket, false);
 
-  int coreWidth = texBuffers.core->width <= 64 ? 64 : texBuffers.core->width;
-  packet2_update(texturePacket,
-                 draw_texture_transfer(texturePacket->base, texture->core->data,
-                                       texture->getWidth(),
-                                       texture->getHeight(), texture->core->psm,
-                                       texBuffers.core->address, coreWidth));
+  packet2_update(
+      texturePacket,
+      draw_texture_transfer(texturePacket->base, texture->core->data,
+                            texture->getWidth(), texture->getHeight(),
+                            texture->core->psm, texBuffers.core->address,
+                            texBuffers.core->width));
 
   if (texBuffers.clut != nullptr) {
     auto* clut = texture->clut;
-    int clutWidth = texBuffers.clut->width <= 64 ? 64 : texBuffers.clut->width;
-    packet2_update(texturePacket,
-                   draw_texture_transfer(texturePacket->next, clut->data,
-                                         clut->width, clut->height, clut->psm,
-                                         texBuffers.clut->address, clutWidth));
+    packet2_update(
+        texturePacket,
+        draw_texture_transfer(texturePacket->next, clut->data, clut->width,
+                              clut->height, clut->psm, texBuffers.clut->address,
+                              texBuffers.clut->width));
   }
 
   packet2_chain_open_cnt(texturePacket, 0, 0, 0);

--- a/engine/src/renderer/core/texture/renderer_core_texture_sender.cpp
+++ b/engine/src/renderer/core/texture/renderer_core_texture_sender.cpp
@@ -58,7 +58,9 @@ texbuffer_t* RendererCoreTextureSender::allocateTextureCore(
   auto* result = new texbuffer_t;
   const auto* core = t_texture->core;
 
-  result->width = t_texture->getWidth();
+  int coreWidth = core->width <= 64 ? 64 : core->width;
+
+  result->width = coreWidth;
   result->psm = core->psm;
   result->info.components = core->components;
 
@@ -77,7 +79,9 @@ texbuffer_t* RendererCoreTextureSender::allocateTextureClut(
   auto* result = new texbuffer_t;
   const auto* clut = t_texture->clut;
 
-  result->width = clut->width;
+  int clutWidth = clut->width <= 64 ? 64 : clut->width;
+
+  result->width = clutWidth;
   result->psm = clut->psm;
   result->info.components = clut->components;
 

--- a/template/.vscode/configurations/windows-docker/tasks.json
+++ b/template/.vscode/configurations/windows-docker/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "shell",
             "label": "1. Copy source code to docker volume",
-            "command": "docker exec -t tyra-game-compiler sh -c 'rsync -ac --delete --exclude \".git\" --exclude \".vscode\" --exclude \"*obj*/**\" --exclude \"*bin*/**\" /host/ /src/'"
+            "command": "docker exec -t tyra-game-compiler sh -c 'rsync -ac --delete --exclude=\".git\" --exclude=\".vscode\" --exclude=\"*obj*/**\" --exclude=\"*bin*/**\" /host/ /src/'"
         },
         {
             "type": "shell",
@@ -34,7 +34,7 @@
         {
             "type": "shell",
             "label": "3. Copy binaries to host",
-            "command": "docker exec -t tyra-game-compiler sh -c 'rsync -zac --include=\"*/\" --include=\"*bin*/**\" --exclude=\"*\" /src/ /host/'",
+            "command": "docker exec -t tyra-game-compiler sh -c 'rsync -zac --include=\"*/\" --include=\"*bin*/**\" --exclude=\"*\" /src/ /host/'"
         },
         {
             "type": "shell",


### PR DESCRIPTION
change core width and clut width.
without this the width is the same if is below 64 and an error occurs with 32x"64 or more" images.
renderer_core_2d.cpp use `packet2_utils_gs_add_texbuff_clut(packet, texBuffers.core, clutBuffer);` and this function need the width be 64 or more. 
![texbuff_clut](https://github.com/h4570/tyra/assets/104105647/8de5828d-ed11-4350-ad61-a644fb69ac67)
