### PR TITLE
Texture generation id

### DIFF
--- a/engine/inc/renderer/core/texture/texture_repository.hpp
+++ b/engine/inc/renderer/core/texture/texture_repository.hpp
@@ -16,6 +16,7 @@
 #include "./models/texture.hpp"
 #include "renderer/3d/mesh/mesh.hpp"
 #include "renderer/core/2d/sprite/sprite.hpp"
+#include "./renderer_core_texture_buffers.hpp"
 #include "loaders/texture/base/texture_loader_selector.hpp"
 #include <string>
 
@@ -24,6 +25,8 @@ class TextureRepository {
  public:
   TextureRepository();
   ~TextureRepository();
+
+  void init(std::vector<RendererCoreTextureBuffers>* textureBuffers);
 
   /** Returns all repository textures. */
   std::vector<Texture*>* getAll() { return &textures; }
@@ -100,6 +103,13 @@ class TextureRepository {
   void freeByMesh(const Mesh* mesh);
 
   /**
+   * remove texture buffer id if exist.
+   * Texture buffer is NOT destructed.
+   * easy way to create another texture buffer.
+   */
+  int removeBufferId(const u32& t_texId);
+
+  /**
    * Remove texture from repository.
    * Texture is NOT destructed.
    * Not recommended.
@@ -110,6 +120,7 @@ class TextureRepository {
   void removeByIndex(const u32& t_index);
 
   std::vector<Texture*> textures;
+  std::vector<RendererCoreTextureBuffers>* textureBuffers;
   TextureLoaderSelector texLoaderSelector;
 };
 }  // namespace Tyra

--- a/engine/src/renderer/core/texture/models/texture.cpp
+++ b/engine/src/renderer/core/texture/models/texture.cpp
@@ -19,7 +19,7 @@
 
 namespace Tyra {
 
-u32 textureCounter = 0;
+u32 textureCounter = 1;
 std::vector<u32> deletedIDs;
 
 Texture::Texture(TextureBuilderData* t_data) {

--- a/engine/src/renderer/core/texture/models/texture.cpp
+++ b/engine/src/renderer/core/texture/models/texture.cpp
@@ -19,8 +19,16 @@
 
 namespace Tyra {
 
+u32 textureCounter = 0;
+std::vector<u32> deletedIDs;
+
 Texture::Texture(TextureBuilderData* t_data) {
-  id = rand() % 1000000;
+  if (deletedIDs.empty() == false) {
+    id = deletedIDs.front();
+    deletedIDs.erase(deletedIDs.begin());
+  } else {
+    id = textureCounter++;
+  }
 
   name = t_data->name;
 
@@ -50,6 +58,7 @@ Texture::Texture(TextureBuilderData* t_data) {
 }
 
 Texture::~Texture() {
+  deletedIDs.push_back(id);
   if (links.size() > 0) links.clear();
   if (core) delete core;
   if (clut) delete clut;

--- a/engine/src/renderer/core/texture/models/texture.cpp
+++ b/engine/src/renderer/core/texture/models/texture.cpp
@@ -19,15 +19,17 @@
 
 namespace Tyra {
 
+namespace TyraTexture {
 u32 textureCounter = 1;
 std::vector<u32> deletedIDs;
+}  // namespace TyraTexture
 
 Texture::Texture(TextureBuilderData* t_data) {
-  if (deletedIDs.empty() == false) {
-    id = deletedIDs.front();
-    deletedIDs.erase(deletedIDs.begin());
+  if (TyraTexture::deletedIDs.empty() == false) {
+    id = TyraTexture::deletedIDs.front();
+    TyraTexture::deletedIDs.erase(TyraTexture::deletedIDs.begin());
   } else {
-    id = textureCounter++;
+    id = TyraTexture::textureCounter++;
   }
 
   name = t_data->name;
@@ -58,7 +60,7 @@ Texture::Texture(TextureBuilderData* t_data) {
 }
 
 Texture::~Texture() {
-  deletedIDs.push_back(id);
+  TyraTexture::deletedIDs.push_back(id);
   if (links.size() > 0) links.clear();
   if (core) delete core;
   if (clut) delete clut;

--- a/engine/src/renderer/core/texture/renderer_core_texture.cpp
+++ b/engine/src/renderer/core/texture/renderer_core_texture.cpp
@@ -19,6 +19,7 @@ RendererCoreTexture::~RendererCoreTexture() {}
 void RendererCoreTexture::init(RendererCoreGS* t_gs, Path3* t_path3) {
   gs = t_gs;
   sender.init(t_path3, t_gs);
+  repository.init(&currentAllocations);
   path3 = t_path3;
   initClut();
 }

--- a/engine/src/renderer/core/texture/texture_repository.cpp
+++ b/engine/src/renderer/core/texture/texture_repository.cpp
@@ -22,6 +22,11 @@ TextureRepository::~TextureRepository() {
   }
 }
 
+void TextureRepository::init(
+    std::vector<RendererCoreTextureBuffers>* t_textureBuffers) {
+  textureBuffers = t_textureBuffers;
+}
+
 Texture* TextureRepository::getBySpriteId(const u32& t_id) const {
   for (u32 i = 0; i < textures.size(); i++) {
     if (textures[i]->isLinkedWith(t_id)) return textures[i];
@@ -57,10 +62,20 @@ void TextureRepository::removeByIndex(const u32& t_index) {
   textures.erase(textures.begin() + t_index);
 }
 
+int TextureRepository::removeBufferId(const u32& t_texId) {
+  for (u32 i = 0; i < textureBuffers->size(); i++)
+    if ((*textureBuffers)[i].id == t_texId) {
+      (*textureBuffers)[i].id = -1;
+      return 0;
+    }
+  return -1;
+}
+
 void TextureRepository::removeById(const u32& t_texId) {
   s32 index = getIndexOf(t_texId);
   TYRA_ASSERT(index != -1, "Cant remove texture, because it was not found!");
   removeByIndex(index);
+  removeBufferId(t_texId);
 }
 
 void TextureRepository::freeByMesh(const Mesh& mesh) {
@@ -93,6 +108,7 @@ void TextureRepository::free(const u32& t_texId) {
 
   TYRA_ASSERT(index != -1, "Cant remove texture, because it was not found!");
   removeByIndex(index);
+  removeBufferId(t_texId);
 
   delete tex;
 }
@@ -116,7 +132,7 @@ void TextureRepository::addByMesh(const Mesh* mesh, const char* directory,
   if (dirFixed.back() != '/' && dirFixed.back() != ':') dirFixed += "/";
 
   for (u32 i = 0; i < mesh->materials.size(); i++) {
-        if (!mesh->materials[i]->textureName.has_value()) {
+    if (!mesh->materials[i]->textureName.has_value()) {
       continue;
     }
 


### PR DESCRIPTION
Texture generation id #129 by the number of textures created, starting from 1 to avoid always creating a texture buffer.
IDs deleted are saved for later use.
TextureRepository now has a pointer over the texture buffers to remove its texture id and create a new one for the next texture with the same id.
Changing the id is an easy way to create another texture buffer, the bad thing is that it is not destroyed until the vram needs it.

If it is accepted, I recommend that the #174  be accepted first.