### PR TITLE
Adds support for texture region repeat

### DIFF
--- a/engine/inc/renderer/core/texture/models/texture.hpp
+++ b/engine/inc/renderer/core/texture/models/texture.hpp
@@ -62,7 +62,8 @@ class Texture {
 
   /** Set texture wrapping */
   void setWrapSettings(const TextureWrap t_horizontal,
-                       const TextureWrap t_vertical);
+                       const TextureWrap t_vertical, int minu = 0, int minv = 0,
+                       int maxu = 0, int maxv = 0);
 
   // ----
   //  Other

--- a/engine/inc/renderer/core/texture/models/texture.hpp
+++ b/engine/inc/renderer/core/texture/models/texture.hpp
@@ -97,9 +97,10 @@ class Texture {
   void print(const std::string& name) const { print(name.c_str()); }
   std::string getPrint(const char* name = nullptr) const;
 
+  void setDefaultWrapSettings();
+
  private:
   void setPsm();
-  void setDefaultWrapSettings();
 
   texwrap_t wrap;
 };

--- a/engine/inc/renderer/core/texture/renderer_core_texture.hpp
+++ b/engine/inc/renderer/core/texture/renderer_core_texture.hpp
@@ -29,6 +29,12 @@ class RendererCoreTexture {
 
   RendererCoreTextureBuffers useTexture(const Texture* t_tex);
 
+  /**
+   * Called by user after changing texture wrap settings
+   * Updates texture packet without reallocate it
+   */
+  RendererCoreTextureBuffers updateTextureInfo(const Texture* t_tex);
+
   /** Called by renderer during initialization */
   void init(RendererCoreGS* gs, Path3* path3);
 

--- a/engine/src/renderer/core/texture/models/texture.cpp
+++ b/engine/src/renderer/core/texture/models/texture.cpp
@@ -167,9 +167,14 @@ void Texture::setDefaultWrapSettings() {
 }
 
 void Texture::setWrapSettings(const TextureWrap t_horizontal,
-                              const TextureWrap t_vertical) {
+                              const TextureWrap t_vertical, int minu, int minv,
+                              int maxu, int maxv) {
   wrap.horizontal = t_horizontal;
   wrap.vertical = t_vertical;
+  wrap.minu = minu;
+  wrap.minv = minv;
+  wrap.maxu = maxu;
+  wrap.maxv = maxv;
 }
 
 void Texture::addLink(const u32& t_id) {

--- a/engine/src/renderer/core/texture/renderer_core_texture.cpp
+++ b/engine/src/renderer/core/texture/renderer_core_texture.cpp
@@ -56,6 +56,17 @@ RendererCoreTextureBuffers RendererCoreTexture::useTexture(
   return newTexBuffer;
 }
 
+RendererCoreTextureBuffers RendererCoreTexture::updateTextureInfo(
+    const Texture* t_tex) {
+  TYRA_ASSERT(t_tex != nullptr, "Provided nullptr texture!");
+
+  auto allocated = getAllocatedBuffersByTextureId(t_tex->id);
+  TYRA_ASSERT(allocated.id != 0, "Can't update an unallocated texture!");
+
+  path3->sendTexture(t_tex, allocated);
+  return allocated;
+}
+
 RendererCoreTextureBuffers RendererCoreTexture::getAllocatedBuffersByTextureId(
     const u32& t_id) {
   for (u32 i = 0; i < currentAllocations.size(); i++)

--- a/tutorials/11-texture-region-repeat/Makefile
+++ b/tutorials/11-texture-region-repeat/Makefile
@@ -1,0 +1,24 @@
+TARGET      := tutorial_11.elf
+ENGINEDIR	:= ../../engine
+
+#The Directories, Source, Includes, Objects, Binary and Resources
+SRCDIR      := src
+INCDIR      := inc
+BUILDDIR    := obj
+TARGETDIR   := bin
+RESDIR      := res
+SRCEXT      := cpp
+VSMEXT		:= vsm
+VCLEXT		:= vcl
+VCLPPEXT	:= vclpp
+DEPEXT      := d
+OBJEXT      := o
+
+#Flags, Libraries and Includes
+CFLAGS      := 
+LIB         := 
+LIBDIRS     := 
+INC         := -I$(INCDIR)
+INCDEP      := -I$(INCDIR)
+
+include ../Makefile.tutorials-base

--- a/tutorials/11-texture-region-repeat/bin/.gitignore
+++ b/tutorials/11-texture-region-repeat/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tutorials/11-texture-region-repeat/inc/tutorial_11.hpp
+++ b/tutorials/11-texture-region-repeat/inc/tutorial_11.hpp
@@ -1,0 +1,58 @@
+/*
+# _____        ____   ___
+#   |     \/   ____| |___|
+#   |     |   |   \  |   |
+#-----------------------------------------------------------------------
+# Copyright 2024, tyra - https://github.com/h4570/tyra
+# Licensed under Apache License 2.0
+# Wellington Carvalho <wellcoj@gmail.com>
+*/
+
+#pragma once
+
+#include <tyra>
+#include <memory>
+
+namespace Tyra {
+
+class Tutorial11 : public Game {
+ public:
+  Tutorial11(Engine* engine);
+  ~Tutorial11();
+
+  void init();
+  void loop();
+
+ private:
+  void setDrawData();
+  void loadBags();
+
+  void setTextureRegionRepeat();
+  void setTextureDefaultWrap();
+
+  const u8 MAX_TILES = 4;
+  u8 TILE_COL = 0;
+  u8 TILE_ROW = 0;
+
+  u8 shouldFlipTextureSettings = false;
+  float limitTimeToFlip = 2.00f;
+  float elapsedTime = 0;
+
+  Engine* engine;
+
+  Vec4 cameraPosition, cameraLookAt;
+  M4x4 translation, rotation, scale, model;
+  Texture* UVCheckerTex;
+
+  std::array<Vec4, 6> vertices;
+  std::array<Color, 6> colors;
+  std::array<Vec4, 6> uvMap;
+
+  StaticPipeline stapip;
+  std::unique_ptr<StaPipBag> bag;
+  std::unique_ptr<StaPipInfoBag> infoBag;
+  std::unique_ptr<StaPipColorBag> colorBag;
+  std::unique_ptr<StaPipTextureBag> texBag;
+};
+
+}  // namespace Tyra

--- a/tutorials/11-texture-region-repeat/inc/tutorial_11.hpp
+++ b/tutorials/11-texture-region-repeat/inc/tutorial_11.hpp
@@ -17,7 +17,7 @@ namespace Tyra {
 
 class Tutorial11 : public Game {
  public:
-  Tutorial11(Engine* engine);
+  explicit Tutorial11(Engine* engine);
   ~Tutorial11();
 
   void init();

--- a/tutorials/11-texture-region-repeat/obj/.gitignore
+++ b/tutorials/11-texture-region-repeat/obj/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tutorials/11-texture-region-repeat/res/.gitignore
+++ b/tutorials/11-texture-region-repeat/res/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tutorials/11-texture-region-repeat/run.ps1
+++ b/tutorials/11-texture-region-repeat/run.ps1
@@ -1,0 +1,4 @@
+$ConfigFile = Join-Path $PSScriptRoot '../../windows-pcsx2.ps1'
+. $ConfigFile
+
+RunPCSX2

--- a/tutorials/11-texture-region-repeat/src/main.cpp
+++ b/tutorials/11-texture-region-repeat/src/main.cpp
@@ -1,0 +1,24 @@
+/*
+# _____        ____   ___
+#   |     \/   ____| |___|
+#   |     |   |   \  |   |
+#-----------------------------------------------------------------------
+# Copyright 2024, tyra - https://github.com/h4570/tyra
+# Licensed under Apache License 2.0
+# Wellington Carvalho <wellcoj@gmail.com>
+*/
+
+#include "engine.hpp"
+#include "tutorial_11.hpp"
+
+/**
+ * In this tutorial we will learn:
+ * - How to use texture in repeate mode of GS
+ */
+
+int main() {
+  Tyra::Engine engine;
+  Tyra::Tutorial11 game(&engine);
+  engine.run(&game);
+  return 0;
+}

--- a/tutorials/11-texture-region-repeat/src/tutorial_11.cpp
+++ b/tutorials/11-texture-region-repeat/src/tutorial_11.cpp
@@ -1,0 +1,178 @@
+/*
+# _____        ____   ___
+#   |     \/   ____| |___|
+#   |     |   |   \  |   |
+#-----------------------------------------------------------------------
+# Copyright 2024, tyra - https://github.com/h4570/tyra
+# Licensed under Apache License 2.0
+# Wellington Carvalho <wellcoj@gmail.com>
+*/
+
+#include <tyra>
+#include "tutorial_11.hpp"
+
+namespace Tyra {
+
+Tutorial11::Tutorial11(Engine* t_engine) : engine(t_engine) {
+  translation = M4x4::Identity;
+  rotation = M4x4::Identity;
+  scale = M4x4::Identity;
+  model = M4x4::Identity;
+
+  rotation.rotateY(Math::PI);
+}
+
+Tutorial11::~Tutorial11() {}
+
+void Tutorial11::init() {
+  stapip.setRenderer(&engine->renderer.core);
+
+  cameraPosition = Vec4(0.0F, 0.0F, -10.0F);
+  cameraLookAt.unit();
+
+  UVCheckerTex = engine->renderer.getTextureRepository().add(
+      FileUtils::fromCwd("uv_checker.png"));
+
+  setDrawData();
+  loadBags();
+}
+
+void Tutorial11::loop() {
+  const auto deltaTime =
+      std::min(1.0f / static_cast<float>(engine->info.getFps()),
+               static_cast<float>(1.0 / 60.0f));
+  elapsedTime += deltaTime;
+
+  if (elapsedTime > limitTimeToFlip) {
+    elapsedTime -= limitTimeToFlip;
+    shouldFlipTextureSettings = !shouldFlipTextureSettings;
+    shouldFlipTextureSettings ? setTextureRegionRepeat()
+                              : setTextureDefaultWrap();
+
+    // Update texture packet info after change wrap settings
+    engine->renderer.core.texture.updateTextureInfo(UVCheckerTex);
+  }
+
+  model = translation * rotation * scale;
+
+  engine->renderer.beginFrame(CameraInfo3D(&cameraPosition, &cameraLookAt));
+  {
+    engine->renderer.renderer3D.usePipeline(stapip);
+
+    /**
+     * Lets draw manually via "bags".
+     * You can do the same thing with dynamic pipeline.
+     */
+    stapip.core.render(bag.get());
+  }
+  engine->renderer.endFrame();
+}
+
+void Tutorial11::setDrawData() {
+  vertices = {
+      // Tri 1
+      Vec4(-3.0F, -3.0F, 0.0F),
+      Vec4(3.0F, -3.0F, 0.0F),
+      Vec4(-3.0F, 3.0F, 0.0F),
+
+      // Tri 2
+      Vec4(3.0F, -3.0F, 0.0F),
+      Vec4(-3.0F, 3.0F, 0.0F),
+      Vec4(3.0F, 3.0F, 0.0F),
+  };
+
+  colors = {
+      Color(128.0F, 128.0F, 128.0F), Color(128.0F, 128.0F, 128.0F),
+      Color(128.0F, 128.0F, 128.0F), Color(128.0F, 128.0F, 128.0F),
+      Color(128.0F, 128.0F, 128.0F), Color(128.0F, 128.0F, 128.0F),
+  };
+
+  setTextureDefaultWrap();
+}
+
+void Tutorial11::setTextureDefaultWrap() {
+  uvMap = {Vec4(0.0f, 1.0F, 1.0F, 0.0f),       Vec4(0.0f + 1, 1.0F, 1.0F, 0.0f),
+           Vec4(0.0f, 0.0f, 1.0F, 0.0f),
+
+           Vec4(0.0f + 1, 1.0F, 1.0F, 0.0f),   Vec4(0.0f, 0.0f, 1.0F, 0.0f),
+           Vec4(0.0f + 1.0F, 0.0f, 1.0F, 0.0f)};
+
+  TYRA_LOG("Reseting texture wrap settings");
+  UVCheckerTex->setDefaultWrapSettings();
+}
+
+void Tutorial11::setTextureRegionRepeat() {
+  const float _scale = 1.0f / (float)MAX_TILES;
+  const Vec4 scale =
+      Vec4(MAX_TILES > 0 ? _scale * MAX_TILES : _scale,
+           MAX_TILES > 0 ? _scale * MAX_TILES : _scale, 1.0f, 0.0f);
+
+  uvMap = {
+      Vec4(TILE_COL, TILE_ROW + 1.0F, 1.0F, 0.0f) * scale,
+      Vec4(TILE_COL + 1, TILE_ROW + 1.0F, 1.0F, 0.0f) * scale,
+      Vec4(TILE_COL, TILE_ROW, 1.0F, 0.0f) * scale,
+
+      Vec4(TILE_COL + 1, TILE_ROW + 1.0F, 1.0F, 0.0f) * scale,
+      Vec4(TILE_COL, TILE_ROW, 1.0F, 0.0f) * scale,
+      Vec4(TILE_COL + 1.0F, TILE_ROW, 1.0F, 0.0f) * scale,
+  };
+
+  const auto tileW = (UVCheckerTex->getWidth() * _scale) - 1;
+  const auto tileH = (UVCheckerTex->getHeight() * _scale) - 1;
+  const auto tileU = TILE_COL * tileW + TILE_COL;
+  const auto tileV = TILE_ROW * tileH + TILE_ROW;
+
+  int minu = tileW;
+  int minv = tileH;
+  int maxu = tileU;
+  int maxv = tileV;
+
+  TYRA_LOG("Changing the texture wraping...");
+  UVCheckerTex->setWrapSettings(TextureWrap::RegionRepeat,
+                                TextureWrap::RegionRepeat, minu, minv, maxu,
+                                maxv);
+
+  TILE_COL++;
+  if (TILE_COL >= MAX_TILES) {
+    TILE_COL %= MAX_TILES;
+    TILE_ROW = (TILE_ROW + 1) % MAX_TILES;
+  }
+}
+
+void Tutorial11::loadBags() {
+  /**
+   * Create info bag and fill it with model matrix and shading type.
+   * Keep rest of the options as default.
+   */
+  infoBag = std::make_unique<StaPipInfoBag>();
+  infoBag->model = &model;
+  infoBag->shadingType = TyraShadingGouraud;
+  infoBag->textureMappingType = TyraNearest;
+
+  /** Create colors bag and set data pointer */
+  colorBag = std::make_unique<StaPipColorBag>();
+  colorBag->many = colors.begin();
+
+  texBag = std::make_unique<StaPipTextureBag>();
+  texBag.get()->texture = UVCheckerTex;
+  texBag.get()->coordinates = uvMap.data();
+
+  /**
+   * Create main bag and set:
+   * - vertices data
+   * - vertices count
+   * - pointers to other bags
+   *
+   * You can add here lighting and texture bag as well.
+   * If you want to have deeper look of this feature, please
+   * read static_pipeline.cpp code file.
+   */
+  bag = std::make_unique<StaPipBag>();
+  bag->color = colorBag.get();
+  bag->texture = texBag.get();
+  bag->info = infoBag.get();
+  bag->vertices = vertices.begin();
+  bag->count = vertices.size();
+}
+
+}  // namespace Tyra


### PR DESCRIPTION
### Main changes: 

- Added methods for changing Texture wrap settings and texture info update.
- Implements support for region repeat described in GS Manual;
- Added tutorial 11 using region repeat

Screenshots of the tutorial:
![tutorial_11_screenshot](https://github.com/h4570/tyra/assets/53970665/c65dbdce-82a0-4fbc-a8e0-b3934cd15b92)
![tutorial_11_screenshot2](https://github.com/h4570/tyra/assets/53970665/303a94bf-210a-4e6d-b913-f9a051b78188)


### Important!
Tutorial 11 needs the attached resource to work ("uv_checker.png");
![uv_checker](https://github.com/h4570/tyra/assets/53970665/fb49096d-4fa6-4230-b47e-798ef655c81d)

