### PR TITLE
Fix demo inversed camera controls

### DIFF
--- a/demo/src/states/game/player/camera.cpp
+++ b/demo/src/states/game/player/camera.cpp
@@ -27,15 +27,15 @@ void Camera::update(const Vec4& playerPosition, const float& terrainHeight) {
   const auto& rightJoy = pad->getRightJoyPad();
 
   if (rightJoy.h <= 100) {
-    circleRotation -= rotationOffset;
-  } else if (rightJoy.h >= 200) {
     circleRotation += rotationOffset;
+  } else if (rightJoy.h >= 200) {
+    circleRotation -= rotationOffset;
   }
 
   if (rightJoy.v <= 100) {
-    height -= heightOffset;
-  } else if (rightJoy.v >= 200) {
     height += heightOffset;
+  } else if (rightJoy.v >= 200) {
+    height -= heightOffset;
   }
 
   unitCircle.x = (sin(circleRotation) * lengthFromOrigin);


### PR DESCRIPTION
The camera controls of the demo were inversed (using PCSX2 default bindings for the Dualsense), it was a bit annoying so I fixed it, cause why not