### PR TITLE
use verbose fileXio to track file open/close/read/seek

### DIFF
--- a/engine/src/irx/fileXio.irx-em
+++ b/engine/src/irx/fileXio.irx-em
@@ -1,2 +1,2 @@
-$PS2SDK/iop/irx/fileXio.irx
+$PS2SDK/iop/irx/fileXio_verbose.irx
 fileXio_irx


### PR DESCRIPTION
mostly intended for PCSX2 usage. although, it will also help on real hardware if redirecting stdout.

when FileXio is loaded, FILEIO surrenders the file handling to it. and since PCSX2 is manipulating FILEIO to track open/close. as soon as you load filexio that information stops reaching the PCSX2 terminal