### PR TITLE
add support for getting angle and setting angle of a mesh

### DIFF
--- a/engine/inc/renderer/3d/mesh/mesh.hpp
+++ b/engine/inc/renderer/3d/mesh/mesh.hpp
@@ -41,7 +41,13 @@ class Mesh {
     return reinterpret_cast<Vec4*>(&translation.data[3 * 4]);
   }
 
+  /** Get angle from rotation matrix */
+  inline Vec4* getRotation() {
+    return reinterpret_cast<Vec4*>(&rotation.data[3 * 4]);
+  }
+
   void setPosition(const Vec4& v);
+  void setAngle(const Vec4& v);
 
  protected:
   void init();

--- a/engine/src/renderer/3d/mesh/mesh.cpp
+++ b/engine/src/renderer/3d/mesh/mesh.cpp
@@ -75,4 +75,9 @@ void Mesh::setPosition(const Vec4& v) {
   reinterpret_cast<Vec4*>(&translation.data[3 * 4])->set(v);
 }
 
+void Mesh::setAngle(const Vec4& v) {
+  TYRA_ASSERT(v.w == 1.0F, "Vec4 must be homogeneous");
+  reinterpret_cast<Vec4*>(&rotation.data[3 * 4])->set(v);
+}
+
 }  // namespace Tyra


### PR DESCRIPTION
Developing a game I realized that in the mesh class, although you could translate position and define an absolute position, you can add a relative rotation, but not define an absolute angle.